### PR TITLE
Update Gemfile to use https instead of unauthenticated git

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
   if File.exist?(library_path) && !ENV['USE_GIT_REPOS']
     gem lib, :path => library_path
   else
-    gem lib, :git => "git://github.com/rspec/#{lib}.git", :branch => branch
+    gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => branch
   end
 end
 


### PR DESCRIPTION
GitHub removed support for unauthed git clones of public repos.