### PR TITLE
Update Gemfile to point to metagem repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,11 @@ branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
   if File.exist?(library_path) && !ENV['USE_GIT_REPOS']
     gem lib, :path => library_path
   else
-    gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => branch
+    if lib == 'rspec'
+      gem 'rspec', :git => "https://github.com/rspec/rspec-metagem.git", :branch => branch
+    else
+      gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => branch
+    end
   end
 end
 


### PR DESCRIPTION
`rspec` needs to get fetched from a different repo, based on this commit in the current version of `rspec-core`:
https://github.com/rspec/rspec-core/commit/5dfc2077eaa2bc812e68240985616081836b4448